### PR TITLE
Add implicit type conversion to Maybe

### DIFF
--- a/Maybe.Test/MaybeTests.cs
+++ b/Maybe.Test/MaybeTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace ZBRA.Maybe.Test
@@ -329,21 +330,44 @@ namespace ZBRA.Maybe.Test
         }
 
         [Fact]
-        public void ImplicitConversion_FromObject_ShouldReturnMaybeWithValue()
-        {
-            var value = new object();
-
-            Maybe<object> subject = value;
-
-            subject.Value.Should().Be(value);
-        }
-
-        [Fact]
         public void ImplicitConversion_FromNullObject_ShouldReturnMaybeWithoutValue()
         {
             Maybe<object> subject = null;
 
             subject.Should().Be(Maybe<object>.Nothing);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonNullData))]
+        public void ImplicitConversion_FromNonNullObject_ShouldReturnMaybeWithValue<T>(T value)
+        {
+            Maybe<T> subject = value;
+
+            subject.Value.Should().Be(value);
+        }
+
+        public static TheoryData<object> NonNullData()
+        {
+            return new TheoryData<object>()
+            {
+                '1',
+                1,
+                1.0,
+                DateTime.Now,
+                new List<string>(),
+                1.ToMaybe(),
+                (1, 2),
+                "1",
+                true,
+                (byte)1,
+                (sbyte)1,
+                (float)1.0,
+                (uint)1,
+                (long)1,
+                (ulong)1,
+                (short)1,
+                (ushort)1,
+            };
         }
     }
 }

--- a/Maybe.Test/MaybeTests.cs
+++ b/Maybe.Test/MaybeTests.cs
@@ -352,6 +352,7 @@ namespace ZBRA.Maybe.Test
             {
                 '1',
                 1,
+                0,
                 1.0,
                 DateTime.Now,
                 new List<string>(),

--- a/Maybe.Test/MaybeTests.cs
+++ b/Maybe.Test/MaybeTests.cs
@@ -328,5 +328,22 @@ namespace ZBRA.Maybe.Test
             subject.Should().ThrowExactly<ArgumentNullException>();
         }
 
+        [Fact]
+        public void ImplicitConversion_FromObject_ShouldReturnMaybeWithValue()
+        {
+            var value = new object();
+
+            Maybe<object> subject = value;
+
+            subject.Value.Should().Be(value);
+        }
+
+        [Fact]
+        public void ImplicitConversion_FromNullObject_ShouldReturnMaybeWithoutValue()
+        {
+            Maybe<object> subject = null;
+
+            subject.Should().Be(Maybe<object>.Nothing);
+        }
     }
 }

--- a/Maybe/Maybe.cs
+++ b/Maybe/Maybe.cs
@@ -47,7 +47,7 @@ namespace ZBRA.Maybe
         /// Returns the value or a default.
         /// </summary>
         /// <returns>
-        /// The value if HasValue is true, otherwise returns defaultValue 
+        /// The value if HasValue is true, otherwise returns defaultValue
         /// </returns>
         /// <param name="defaultValue"> The default value.</param>
         public T Or(T defaultValue) => HasValue ? obj : defaultValue;
@@ -216,7 +216,7 @@ namespace ZBRA.Maybe
         /// Determines if this instance is equals to another obj instance.
         /// </summary>
         /// <returns>
-        /// True if obj is an instance of Maybe&lt;<typeparamref name="T"/>&gt; 
+        /// True if obj is an instance of Maybe&lt;<typeparamref name="T"/>&gt;
         /// and it matches the current instance using Equals(Maybe&lt;T&gt; other).
         /// False otherwise
         /// </returns>
@@ -240,10 +240,10 @@ namespace ZBRA.Maybe
         public override string ToString() => HasValue ? Value.ToString() : string.Empty;
 
         /// <summary>
-        /// Comparison method responsible for ordering or sorting collections of <see cref="Maybe{T}" />. <br/>    
-        /// A return of 0 means that both maybes are equal.<br/>     
-        /// A return of -1 means that this instance of maybe is less than the other maybe being compared.<br/>     
-        /// A return of 1 means that this instance of maybe is greater than the other maybe being compared.<br/>  
+        /// Comparison method responsible for ordering or sorting collections of <see cref="Maybe{T}" />. <br/>
+        /// A return of 0 means that both maybes are equal.<br/>
+        /// A return of -1 means that this instance of maybe is less than the other maybe being compared.<br/>
+        /// A return of 1 means that this instance of maybe is greater than the other maybe being compared.<br/>
         /// </summary>
         /// <param name="other">The other <see cref="Maybe{T}" /> to compare</param>
         /// <returns>
@@ -318,6 +318,25 @@ namespace ZBRA.Maybe
         /// <param name="right">The second <see cref="Maybe{T}" /> to compare.</param>
         /// <returns>A boolean indicating whether or not the <see cref="Maybe{T}" /> are unequal.</returns>
         public static bool operator !=(Maybe<T> left, Maybe<T> right) => !left.Equals(right);
+        #endregion
+
+        #region Implicit type conversion
+        /// <summary>
+        /// Converts the value to <see cref="Maybe{T}" />.
+        /// </summary>
+        /// <param name="value"> The value to be converted.</param>
+        /// <returns>
+        /// <see cref="Maybe{T}" />.Nothing if value is null,
+        /// otherwise new <see cref="Maybe{T}" />(value)
+        /// </returns>
+        public static implicit operator Maybe<T>(T value)
+        {
+            if (value == null)
+            {
+                return Nothing;
+            }
+            return new Maybe<T>(value);
+        }
         #endregion
     }
 }

--- a/Maybe/Maybe.csproj
+++ b/Maybe/Maybe.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/zbra-solutions/maybe</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <AssemblyName>ZBRA.Maybe</AssemblyName>
     <RootNamespace>ZBRA.Maybe</RootNamespace>
   </PropertyGroup>

--- a/Maybe/Maybe.csproj
+++ b/Maybe/Maybe.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/zbra-dev/maybe</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>0.3.0</Version>
+    <Version>1.0.0</Version>
     <AssemblyName>ZBRA.Maybe</AssemblyName>
     <RootNamespace>ZBRA.Maybe</RootNamespace>
   </PropertyGroup>

--- a/Maybe/Maybe.csproj
+++ b/Maybe/Maybe.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>ZBRA.Maybe</PackageId>
-    <Authors>ZBRA Solutions</Authors>
+    <Authors>ZBRA</Authors>
     <PackageDescription>
       An utility library that helps avoiding nulls.
     </PackageDescription>
-    <PackageProjectUrl>https://github.com/zbra-solutions/maybe</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/zbra-solutions/maybe</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/zbra-dev/maybe</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/zbra-dev/maybe</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Version>0.3.0</Version>

--- a/Maybe/MaybeExtensions.cs
+++ b/Maybe/MaybeExtensions.cs
@@ -107,17 +107,13 @@ namespace ZBRA.Maybe
         /// <param name="value"> The value to be converted.</param>
         public static Maybe<T> ToMaybe<T>(this T value)
         {
-            if (value == null)
-            {
-                return Maybe<T>.Nothing;
-            }
-
-            return new Maybe<T>(value);
+            // Using implicit conversion
+            return value;
         }
 
         #endregion
 
-        #region Operations 
+        #region Operations
         /// <summary>
         /// Projects the value according to the selector.
         /// Analogous to Linq's Select.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A maybe monad for C#.
 
 A maybe monad is a good way to avoid nulls. So you avoid returning null by doing:
 
-```
+```c#
 public Maybe<string> Foo()
 {
     if (checkThis())
@@ -21,7 +21,7 @@ Because `Maybe<T>` is a struct this means it cannot have a null value. So instea
 
 There are multiple ways to retrieve the value of a `Maybe<T>`.
 
-```
+```c#
 var maybe = "some value".ToMaybe();
 
 // this will throw if it has no value
@@ -46,7 +46,7 @@ var s = maybe.ToNullable();
 
 There are other ways of using it in a more fluent-like API.
 
-```
+```c#
 var maybe = "some value".ToMaybe();
 
 // CallMethod is only called if maybe has a value
@@ -58,7 +58,7 @@ var result = maybe.Where(s => s.StartsWith("some"));
 
 Comparing maybes is also supported.
 
-```
+```c#
 var a = 10.ToMaybe();
 var b = 0.ToMaybe();
 
@@ -72,5 +72,18 @@ b = int.MinValue;
 if (a < b)
 {
     // Nothing will always be less than any int value
+}
+```
+
+It is also possible to implicitly cast any object of type `T` to a `Maybe<T>`. For example, the following snippets are valid:
+
+```c#
+Maybe<int> a = 10;
+```
+
+```c#
+public Maybe<double> Foo()
+{
+   return 1.0;
 }
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,13 +27,17 @@ steps:
     command: restore
     restoreSolution: '**/*.sln'
 
+- task: UseDotNet@2
+  inputs:
+    version: 3.1.x
+
 - task: DotNetCoreCLI@2
   displayName: Build
   inputs:
     command: build
     projects: '**/*.csproj'
     workingDirectory: $(Build.SourcesDirectory)
-  
+
 - task: DotNetCoreCLI@2
   displayName: Test
   inputs:


### PR DESCRIPTION
Addressing issue #37.

Some suggestions on what to do about the extension `public static Maybe<T> ToMaybe<T>(this T value)` would be nice.